### PR TITLE
fix: 修复拖出浏览器窗口时遮罩不消失，并优化拖拽区域动画

### DIFF
--- a/vue3/src/views/chat-home/components/ChatHomeChatCol.vue
+++ b/vue3/src/views/chat-home/components/ChatHomeChatCol.vue
@@ -225,7 +225,7 @@ const handleImageDrop = (e: DragEvent) => {
             <!-- 文件 -->
             <div
               ref="FolderRef"
-              class="zone-animate flex flex-1 flex-col items-center justify-center gap-2 border-[3.5px] border-dashed text-[20px] font-bold text-color-text-soft"
+              class="zone-animate flex flex-1 border-[3.5px] border-dashed"
               :class="[
                 isHoveringFileZone ? 'border-glow' : 'border-color-text-soft',
                 FilesOrImages
@@ -237,22 +237,29 @@ const handleImageDrop = (e: DragEvent) => {
               @dragover="handleZoneDragOver"
               @drop="handleFileDrop"
             >
-              <RiFolderLine
-                size="40px"
-                class="pointer-events-none"
-              ></RiFolderLine>
-              <h1 v-if="isHoveringFileZone" class="pointer-events-none">
-                {{ i18nStore.t('chatDragZoneReleaseText')() }}
-              </h1>
-              <h1 v-else class="pointer-events-none">
-                {{ i18nStore.t('chatDragZoneFilePlaceholderText')() }}
-              </h1>
+              <!-- 文字容器 -->
+              <div
+                class="pointer-events-none flex h-full w-full flex-col items-center justify-center gap-2 text-[20px] font-bold text-color-text-soft transition-all duration-500 ease-out"
+                :class="isHoveringFileZone ? 'opacity-100' : 'opacity-70'"
+              >
+                <RiFolderLine
+                  size="40px"
+                  class="pointer-events-none"
+                ></RiFolderLine>
+                <h1 class="pointer-events-none">
+                  {{
+                    isHoveringFileZone
+                      ? i18nStore.t('chatDragZoneReleaseText')()
+                      : i18nStore.t('chatDragZoneFilePlaceholderText')()
+                  }}
+                </h1>
+              </div>
             </div>
             <!-- 图片 -->
             <div
               v-if="FilesOrImages"
               ref="ImageRef"
-              class="zone-animate flex flex-1 flex-col items-center justify-center gap-2 rounded-b-[24px] rounded-t-[8px] border-[3.5px] border-dashed text-[20px] font-bold text-color-text-soft"
+              class="zone-animate flex flex-1 rounded-b-[24px] rounded-t-[8px] border-[3.5px] border-dashed"
               :class="
                 isHoveringImageZone ? 'border-glow' : 'border-color-text-soft'
               "
@@ -261,16 +268,23 @@ const handleImageDrop = (e: DragEvent) => {
               @dragover="handleZoneDragOver"
               @drop="handleImageDrop"
             >
-              <RiImageLine
-                size="40px"
-                class="pointer-events-none"
-              ></RiImageLine>
-              <h1 v-if="isHoveringImageZone" class="pointer-events-none">
-                {{ i18nStore.t('chatDragZoneReleaseText')() }}
-              </h1>
-              <h1 v-else class="pointer-events-none">
-                {{ i18nStore.t('chatDragZoneImagePlaceholderText')() }}
-              </h1>
+              <!-- 文字容器 -->
+              <div
+                class="pointer-events-none flex h-full w-full flex-col items-center justify-center gap-2 text-[20px] font-bold text-color-text-soft transition-all duration-500 ease-out"
+                :class="isHoveringImageZone ? 'opacity-100' : 'opacity-70'"
+              >
+                <RiImageLine
+                  size="40px"
+                  class="pointer-events-none"
+                ></RiImageLine>
+                <h1 class="pointer-events-none">
+                  {{
+                    isHoveringImageZone
+                      ? i18nStore.t('chatDragZoneReleaseText')()
+                      : i18nStore.t('chatDragZoneImagePlaceholderText')()
+                  }}
+                </h1>
+              </div>
             </div>
           </div>
         </div>

--- a/vue3/src/views/chat-home/components/ChatHomeChatCol.vue
+++ b/vue3/src/views/chat-home/components/ChatHomeChatCol.vue
@@ -93,9 +93,21 @@ const handleDragEnter = (e: DragEvent) => {
 }
 const handleDragLeave = (e: DragEvent) => {
   e.preventDefault()
+  // 修复拖出浏览器窗口时，dragCounter 不归零导致的遮罩不消失问题
+  if (
+    e.clientX <= 0 ||
+    e.clientY <= 0 ||
+    e.clientX >= window.innerWidth ||
+    e.clientY >= window.innerHeight
+  ) {
+    dragCounter = 0
+    isDragging.value = false
+    isHoveringFileZone.value = false
+    isHoveringImageZone.value = false
+    return
+  }
+  // 过滤非文件
   if (e.dataTransfer && e.dataTransfer.types.includes('Files')) {
-    // dragCounter--
-    // if (dragCounter === 0) {
     dragCounter = Math.max(0, dragCounter - 1)
     if (dragCounter <= 0) {
       dragCounter = 0
@@ -206,24 +218,20 @@ const handleImageDrop = (e: DragEvent) => {
       >
         <!-- 固定窗口位置 -->
         <div class="sticky top-0 flex h-dvh w-full">
-          <!--
-          enterActiveClass="transition-all duration-300 ease-[cubic-bezier(0.22,1,0.36,1)]"
-          leaveActiveClass="transition-all duration-200 ease-in"
-          enterFromClass="opacity-0 scale-[0.98]"
-          enterToClass="opacity-100 scale-100"
-          leaveFromClass="opacity-100 scale-100"
-          leaveToClass="opacity-0 scale-[0.98]"
-         -->
+          <!-- 显示 文件/图片 -->
           <div
             class="mx-[2000px] mb-[52px] mt-[40px] flex w-full flex-col gap-[8px]"
           >
             <!-- 文件 -->
             <div
               ref="FolderRef"
-              class="flex flex-1 flex-col items-center justify-center gap-2 rounded-b-[8px] rounded-t-[24px] border-[3.5px] border-dashed text-[20px] font-bold text-color-text-soft"
-              :class="
-                isHoveringFileZone ? 'border-glow' : 'border-color-text-soft'
-              "
+              class="flex flex-1 flex-col items-center justify-center gap-2 border-[3.5px] border-dashed text-[20px] font-bold text-color-text-soft"
+              :class="[
+                isHoveringFileZone ? 'border-glow' : 'border-color-text-soft',
+                FilesOrImages
+                  ? 'active-style rounded-b-[8px] rounded-t-[24px]'
+                  : 'normal-style rounded-[24px]',
+              ]"
               @dragenter="handleFileZoneDragEnter"
               @dragleave="handleFileZoneDragLeave"
               @dragover="handleZoneDragOver"

--- a/vue3/src/views/chat-home/components/ChatHomeChatCol.vue
+++ b/vue3/src/views/chat-home/components/ChatHomeChatCol.vue
@@ -225,7 +225,7 @@ const handleImageDrop = (e: DragEvent) => {
             <!-- 文件 -->
             <div
               ref="FolderRef"
-              class="flex flex-1 flex-col items-center justify-center gap-2 border-[3.5px] border-dashed text-[20px] font-bold text-color-text-soft"
+              class="zone-animate flex flex-1 flex-col items-center justify-center gap-2 border-[3.5px] border-dashed text-[20px] font-bold text-color-text-soft"
               :class="[
                 isHoveringFileZone ? 'border-glow' : 'border-color-text-soft',
                 FilesOrImages
@@ -252,7 +252,7 @@ const handleImageDrop = (e: DragEvent) => {
             <div
               v-if="FilesOrImages"
               ref="ImageRef"
-              class="flex flex-1 flex-col items-center justify-center gap-2 rounded-b-[24px] rounded-t-[8px] border-[3.5px] border-dashed text-[20px] font-bold text-color-text-soft"
+              class="zone-animate flex flex-1 flex-col items-center justify-center gap-2 rounded-b-[24px] rounded-t-[8px] border-[3.5px] border-dashed text-[20px] font-bold text-color-text-soft"
               :class="
                 isHoveringImageZone ? 'border-glow' : 'border-color-text-soft'
               "
@@ -338,12 +338,14 @@ const handleImageDrop = (e: DragEvent) => {
 </template>
 
 <style lang="scss" scoped>
-.border-glow {
-  border-color: white;
-
+.zone-animate {
   transition:
     border-color 0.28s ease,
     box-shadow 0.28s ease;
+}
+
+.border-glow {
+  border-color: white;
 
   box-shadow:
     0 0 16px rgba(255, 255, 255, 0.14),


### PR DESCRIPTION
## 改动内容
主要优化聊天页拖拽上传体验，修复一个拖拽状态问题

- 修复快速拖出浏览器窗口再拖回来时遮罩不消失的问题
- 优化拖拽区域高亮动画效果
- 优化拖拽区域文字过渡动画
- 调整拖拽区域的样式结构，使动画更平滑
- 改进文件 / 图片拖拽识别逻辑

## 结果：
- 拖拽状态更稳定
- 动画更平滑
- UI 反馈更自然

## 测试方式
1. 反复快速拖拽文件，让文件反复快速离开浏览器再回来
3. 在文件 / 图片区域来回拖动，观察离开某一判断区域时高亮的消失是否平滑
4. 同上，观察文字的变化是否平滑